### PR TITLE
Add Jetcaster's tv and wear modules

### DIFF
--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -42,12 +42,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [ Reply.app, Jetcaster.mobile ]
+        app: [ Reply.app, Jetcaster.mobile, Jetcaster.tv ]
         include:
           - app: Reply.app
             app-activity: com.example.reply.ui.MainActivity
           - app: Jetcaster.mobile
             app-activity: com.example.jetcaster.ui.MainActivity
+          - app: Jetcaster.tv
+            app-activity: com.example.jetcaster.tv.MainActivity
     steps:
       - uses: coursier/cache-action@v6
       - uses: actions/checkout@v4

--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [ Reply.app, Jetcaster.mobile, Jetcaster.tv ]
+        app: [ Reply.app, Jetcaster.mobile, Jetcaster.tv, Jetcaster.wear ]
         include:
           - app: Reply.app
             app-activity: com.example.reply.ui.MainActivity
@@ -50,6 +50,8 @@ jobs:
             app-activity: com.example.jetcaster.ui.MainActivity
           - app: Jetcaster.tv
             app-activity: com.example.jetcaster.tv.MainActivity
+          - app: Jetcaster.tv
+            app-activity: com.example.jetcaster.wear.MainActivity
     steps:
       - uses: coursier/cache-action@v6
       - uses: actions/checkout@v4

--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -50,7 +50,7 @@ jobs:
             app-activity: com.example.jetcaster.ui.MainActivity
           - app: Jetcaster.tv
             app-activity: com.example.jetcaster.tv.MainActivity
-          - app: Jetcaster.tv
+          - app: Jetcaster.wear
             app-activity: com.example.jetcaster.wear.MainActivity
     steps:
       - uses: coursier/cache-action@v6

--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -51,7 +51,7 @@ jobs:
           - app: Jetcaster.tv
             app-activity: com.example.jetcaster.tv.MainActivity
           - app: Jetcaster.wear
-            app-activity: com.example.jetcaster.wear.MainActivity
+            app-activity: .JetcasterWearApplication
     steps:
       - uses: coursier/cache-action@v6
       - uses: actions/checkout@v4

--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -51,7 +51,7 @@ jobs:
           - app: Jetcaster.tv
             app-activity: com.example.jetcaster.tv.MainActivity
           - app: Jetcaster.wear
-            app-activity: .JetcasterWearApplication
+            app-activity: .MainActivity
     steps:
       - uses: coursier/cache-action@v6
       - uses: actions/checkout@v4

--- a/Jetcaster/package.mill
+++ b/Jetcaster/package.mill
@@ -214,13 +214,6 @@ object mobile extends BaseHiltAndroidModule, AndroidR8AppModule {
       isMinifyEnabled = false
     )
   }
-
-  override def androidLibsRClasses = Task {
-    (super.androidLibsRClasses()
-      ++ os.walk(androidLinkedResources().path / "generatedSources").filter(
-      os.isFile
-    ).filter(_.ext == "java").map(PathRef(_))).distinct
-  }
   
   def androidProjectProguardFiles = Task.Sources(
     "proguard-rules.pro"
@@ -289,6 +282,165 @@ object mobile extends BaseHiltAndroidModule, AndroidR8AppModule {
   ) ++ (if (androidIsDebug()) debugMvnDeps() else Seq())
 
   override def androidExcludePackageFiles: T[Seq[Regex]] =
-    super.androidExcludePackageFiles() ++ Seq[Regex]("/*.jar".r)
+    Seq[Regex]("/*.jar".r)
 
+}
+
+object tv extends BaseHiltAndroidModule, AndroidR8AppModule {
+  override def androidApplicationNamespace: String = "com.example.jetcaster"
+
+  override def androidApplicationId: String = "com.example.jetcaster"
+
+  def androidEnableCompose: T[Boolean] = true
+
+  def bomMvnDeps: T[Seq[Dep]] = Seq(
+    mvn"androidx.compose:compose-bom-alpha:2025.06.00"
+  )
+
+  def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
+    mvn"com.google.dagger:hilt-compiler:2.56.2",
+  )
+
+  override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
+    AndroidBuildTypeSettings(
+      isMinifyEnabled = false
+    )
+  }
+
+  def androidProjectProguardFiles = Task.Sources(
+    "proguard-rules.pro"
+  )
+
+  def androidDefaultProguardFileNames: Task[Seq[String]] = Task.Anon {
+    Seq("proguard-android-optimize.txt")
+  }
+
+
+  private def debugMvnDeps: T[Seq[Dep]] = Task {
+    Seq(
+
+    )
+  }
+
+  def moduleDeps = super.moduleDeps ++ Seq(
+    core.data,
+    core.designsystem,
+    core.domain,
+    core.`domain-testing`
+  )
+
+
+  override def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
+
+  ) ++ (if (androidIsDebug()) debugMvnDeps() else Seq())
+
+
+  override def androidExcludePackageFiles: T[Seq[Regex]] =
+    Seq[Regex]("^/META-INF/(AL2.0|LGPL2.1)$".r, "/*.jar".r, "/*.jar".r)
+
+  // Use google-tv image
+  override def sdkInstallSystemImage(): Command[String] = Task.Command {
+    val image =
+      s"system-images;${androidSdkModule().platformsVersion()};google-tv;$androidEmulatorArchitecture"
+    Task.log.info(s"Downloading $image")
+    val installCall = os.call((
+      androidSdkModule().sdkManagerExe().path,
+      "--install",
+      image
+    ))
+
+    if (installCall.exitCode != 0) {
+      Task.log.error(
+        s"Error trying to install android emulator system image ${installCall.err.text()}"
+      )
+      throw new Exception(s"Failed to install system image $image: ${installCall.exitCode}")
+    }
+    image
+  }
+}
+
+
+object wear extends BaseHiltAndroidModule, AndroidR8AppModule {
+  override def androidApplicationNamespace: String = "com.example.jetcaster"
+
+  override def androidApplicationId: String = "com.example.jetcaster"
+
+  override def androidMinSdk: T[Int] = 26
+
+  override def androidTargetSdk: T[Int] = 34
+
+  def androidEnableCompose: T[Boolean] = true
+
+  def bomMvnDeps: T[Seq[Dep]] = Seq(
+    mvn"androidx.compose:compose-bom-alpha:2025.06.00"
+  )
+
+  def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
+    mvn"com.google.dagger:hilt-compiler:2.56.2",
+  )
+
+  override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
+    AndroidBuildTypeSettings(
+      isMinifyEnabled = false
+    )
+  }
+
+  def androidProjectProguardFiles = Task.Sources(
+    "proguard-rules.pro"
+  )
+
+  def androidDefaultProguardFileNames: Task[Seq[String]] = Task.Anon {
+    Seq("proguard-android-optimize.txt")
+  }
+
+
+  private def debugMvnDeps: T[Seq[Dep]] = Task {
+    Seq(
+
+    )
+  }
+
+  def moduleDeps = super.moduleDeps ++ Seq(
+    core.data,
+    core.designsystem,
+    core.domain,
+    core.`domain-testing`
+  )
+
+
+  override def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
+
+  ) ++ (if (androidIsDebug()) debugMvnDeps() else Seq())
+
+
+  override def androidExcludePackageFiles: T[Seq[Regex]] =
+    Seq[Regex]("^/META-INF/(AL2.0|LGPL2.1)$".r, "/*.jar".r, "^rome-utils-.*\\.jar$".r)
+
+
+  // Use android-wear image
+  override def sdkInstallSystemImage(): Command[String] = Task.Command {
+    val image =
+      s"system-images;android-34;android-wear;$androidEmulatorArchitecture"
+    Task.log.info(s"Downloading $image")
+    val installCall = os.call((
+      androidSdkModule().sdkManagerExe().path,
+      "--install",
+      image
+    ))
+
+    if (installCall.exitCode != 0) {
+      Task.log.error(
+        s"Error trying to install android emulator system image ${installCall.err.text()}"
+      )
+      throw new Exception(s"Failed to install system image $image: ${installCall.exitCode}")
+    }
+    image
+  }
+
+  override def kotlincOptions: T[Seq[String]] =
+    super.kotlincOptions()
+    ++ Seq(
+      "-opt-in=kotlin.RequiresOptIn",
+      "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
+    )
 }

--- a/Jetcaster/package.mill
+++ b/Jetcaster/package.mill
@@ -38,11 +38,6 @@ trait BaseAndroidModule extends AndroidKotlinModule {
     androidUnpackRunArchives().flatMap(_.manifest) ++ androidDirectModuleDepsManifests()
   }
 
-  // https://android.googlesource.com/platform/tools/base/+/refs/heads/mirror-goog-studio-main/build-system/builder/src/main/java/com/android/builder/internal/aapt/v2/AaptV2CommandBuilder.kt#326
-  override def androidAaptOptions = Task {
-    super.androidAaptOptions() ++ Seq("--non-final-ids")
-  }
-
 }
 
 trait BaseHiltAndroidModule extends BaseAndroidModule, AndroidHiltSupport {
@@ -193,7 +188,7 @@ object glancewidget extends BaseAndroidModule {
   )
 }
 
-trait BaseJetcasterAppModule extends BaseHiltAndroidModule, AndroidR8AppModule {
+trait BaseJetcasterAppModule extends BaseHiltAndroidModule, AndroidAppKotlinModule, AndroidR8AppModule {
   override def androidApplicationNamespace: String = "com.example.jetcaster"
 
   override def androidApplicationId: String = "com.example.jetcaster"
@@ -356,36 +351,21 @@ object tv extends BaseJetcasterAppModule {
   override def androidExcludePackageFiles: T[Seq[Regex]] =
     Seq[Regex]("^/META-INF/(AL2.0|LGPL2.1)$".r, "/*.jar".r, "/*.jar".r)
 
+  override def androidVirtualDevice = AndroidVirtualDevice(
+    apiVersion = "android-34",
+    architecture = "x86",
+    deviceId = "tv_1080p",
+    systemImageSource = "android-tv"
+  )
 
-  // Use system-images;android-34;android-tv;x86 image
-  override def androidEmulatorArchitecture = "x86"
-
-  override def androidVirtualDeviceIdentifier = "test-tv"
-
-  override def androidDeviceId = "tv_1080p"
-
-  override def sdkInstallSystemImage(): Command[String] = Task.Command {
-    val image =
-      s"system-images;android-34;android-tv;$androidEmulatorArchitecture"
-    Task.log.info(s"Downloading $image")
-    val installCall = os.call((
-      androidSdkModule().sdkManagerExe().path,
-      "--install",
-      image
-    ))
-
-    if (installCall.exitCode != 0) {
-      Task.log.error(
-        s"Error trying to install android emulator system image ${installCall.err.text()}"
-      )
-      throw new Exception(s"Failed to install system image $image: ${installCall.exitCode}")
-    }
-    image
-  }
 }
 
 
 object wear extends BaseJetcasterAppModule {
+
+  override def androidMinSdk: T[Int] = Task {26}
+
+  override def androidTargetSdk: T[Int] = Task {34}
 
   private def debugMvnDeps: T[Seq[Dep]] = Task {
     Seq(
@@ -432,6 +412,7 @@ object wear extends BaseJetcasterAppModule {
 
     mvn"androidx.compose.ui:ui-tooling-preview",
     mvn"androidx.compose.ui:ui-tooling",
+    mvn"androidx.wear.compose:compose-ui-tooling:1.5.0-beta03",
 
     mvn"androidx.wear.compose:compose-navigation:1.5.0-beta03",
     mvn"androidx.compose.ui:ui-test-manifest",
@@ -442,31 +423,12 @@ object wear extends BaseJetcasterAppModule {
   override def androidExcludePackageFiles: T[Seq[Regex]] =
     Seq[Regex]("^/META-INF/(AL2.0|LGPL2.1)$".r, "/*.jar".r, "^rome-utils-.*\\.jar$".r)
 
-
-  // Use system-images;android-34;android-tv;x86_64 image
-
-  override def androidVirtualDeviceIdentifier = "test-wear"
-
-  override def androidDeviceId = "wearos_large_round"
-
-  override def sdkInstallSystemImage(): Command[String] = Task.Command {
-    val image =
-      s"system-images;android-34;android-wear;$androidEmulatorArchitecture"
-    Task.log.info(s"Downloading $image")
-    val installCall = os.call((
-      androidSdkModule().sdkManagerExe().path,
-      "--install",
-      image
-    ))
-
-    if (installCall.exitCode != 0) {
-      Task.log.error(
-        s"Error trying to install android emulator system image ${installCall.err.text()}"
-      )
-      throw new Exception(s"Failed to install system image $image: ${installCall.exitCode}")
-    }
-    image
-  }
+  override def androidVirtualDevice = AndroidVirtualDevice(
+    apiVersion = "android-34",
+    architecture = "x86_64",
+    deviceId = "wearos_large_round",
+    systemImageSource = "android-wear"
+  )
 
   override def kotlincOptions: T[Seq[String]] =
     super.kotlincOptions()
@@ -475,5 +437,18 @@ object wear extends BaseJetcasterAppModule {
       "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
     )
 
-  // TODO: Add androidTest
+  // FIXME
+  // Currently not working
+  object test extends AndroidAppKotlinTests, TestModule.Junit4 {
+    def junit4Version = "4.13.2"
+
+    override def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
+      mvn"androidx.compose.ui:ui-test-junit4",
+      mvn"org.robolectric:robolectric:4.14.1",
+      // Resolve conflicts
+      mvn"androidx.test.ext:junit:1.2.1".forceVersion(),
+      mvn"androidx.test:monitor:1.7.2".forceVersion(),
+      mvn"androidx.test.services:storage:1.5.0".forceVersion()
+    )
+  }
 }

--- a/Jetcaster/package.mill
+++ b/Jetcaster/package.mill
@@ -5,7 +5,7 @@ import androidlib.*
 import kotlinlib.*
 import build.*
 import mill.api.Task.Simple as T
-import mill.api.{PathRef, Task}
+import mill.api.{PathRef, Task, BuildCtx}
 import mill.javalib.api.JvmWorkerApi
 import mill.kotlinlib.ksp.KspModule
 import hilt.AndroidHiltSupport
@@ -193,8 +193,7 @@ object glancewidget extends BaseAndroidModule {
   )
 }
 
-object mobile extends BaseHiltAndroidModule, AndroidR8AppModule {
-
+trait BaseJetcasterAppModule extends BaseHiltAndroidModule, AndroidR8AppModule {
   override def androidApplicationNamespace: String = "com.example.jetcaster"
 
   override def androidApplicationId: String = "com.example.jetcaster"
@@ -214,14 +213,43 @@ object mobile extends BaseHiltAndroidModule, AndroidR8AppModule {
       isMinifyEnabled = false
     )
   }
-  
+
   def androidProjectProguardFiles = Task.Sources(
     "proguard-rules.pro"
   )
+
   def androidDefaultProguardFileNames: Task[Seq[String]] = Task.Anon {
     Seq("proguard-android-optimize.txt")
   }
 
+
+  def androidComposeCompilerLogsDir = Task{
+    Task.dest
+  }
+
+  //https://gist.github.com/fvilarino/730ab202d798ff10565112532a08f8df
+  def androidComposeCompilerArgs: T[Map[String,String]] = Task {
+    Map(
+      "reportsDestination" -> androidComposeCompilerLogsDir().toString,
+      "metricsDestination" -> androidComposeCompilerLogsDir().toString,
+      "stabilityConfigurationPath" ->
+        (BuildCtx.workspaceRoot / "Jetcaster" / "stability_config.conf").toString
+    )
+  }
+
+  override def kotlincOptions: T[Seq[String]] = {
+    val composeCompilerPluginId = "plugin:androidx.compose.compiler.plugins.kotlin"
+    super.kotlincOptions()
+    ++ androidComposeCompilerArgs().flatMap({ case (key, value) =>
+      Seq(
+        "-P",
+        s"$composeCompilerPluginId:$key=$value"
+      )
+    })
+  }
+}
+
+object mobile extends BaseJetcasterAppModule {
 
   // Missing org.jaxen.*
   override def androidR8Args = Seq(
@@ -286,39 +314,12 @@ object mobile extends BaseHiltAndroidModule, AndroidR8AppModule {
 
 }
 
-object tv extends BaseHiltAndroidModule, AndroidR8AppModule {
-  override def androidApplicationNamespace: String = "com.example.jetcaster"
-
-  override def androidApplicationId: String = "com.example.jetcaster"
-
-  def androidEnableCompose: T[Boolean] = true
-
-  def bomMvnDeps: T[Seq[Dep]] = Seq(
-    mvn"androidx.compose:compose-bom-alpha:2025.06.00"
-  )
-
-  def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
-    mvn"com.google.dagger:hilt-compiler:2.56.2",
-  )
-
-  override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
-    AndroidBuildTypeSettings(
-      isMinifyEnabled = false
-    )
-  }
-
-  def androidProjectProguardFiles = Task.Sources(
-    "proguard-rules.pro"
-  )
-
-  def androidDefaultProguardFileNames: Task[Seq[String]] = Task.Anon {
-    Seq("proguard-android-optimize.txt")
-  }
-
+object tv extends BaseJetcasterAppModule {
 
   private def debugMvnDeps: T[Seq[Dep]] = Task {
     Seq(
-
+      mvn"androidx.compose.ui:ui-tooling",
+      mvn"androidx.compose.ui:ui-test-manifest"
     )
   }
 
@@ -326,11 +327,27 @@ object tv extends BaseHiltAndroidModule, AndroidR8AppModule {
     core.data,
     core.designsystem,
     core.domain,
-    core.`domain-testing`
   )
 
 
   override def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
+    mvn"androidx.core:core-ktx:1.16.0",
+    mvn"androidx.appcompat:appcompat:1.7.1",
+    mvn"androidx.compose.ui:ui-tooling-preview",
+    mvn"androidx.tv:tv-material:1.0.0",
+    mvn"androidx.lifecycle:lifecycle-runtime-ktx:2.9.1",
+    mvn"androidx.lifecycle:lifecycle-runtime-compose:2.9.1",
+    mvn"androidx.activity:activity-compose:1.10.1",
+    mvn"androidx.navigation:navigation-compose:2.9.0",
+
+    // Hilt
+    mvn"androidx.hilt:hilt-navigation-compose:1.2.0",
+    mvn"com.google.dagger:hilt-android:2.56.2",
+
+    // Media3
+    mvn"androidx.media3:media3-exoplayer:1.7.1",
+    mvn"androidx.media3:media3-session:1.7.1",
+    mvn"androidx.media3:media3-ui-compose:1.7.1",
 
   ) ++ (if (androidIsDebug()) debugMvnDeps() else Seq())
 
@@ -360,39 +377,7 @@ object tv extends BaseHiltAndroidModule, AndroidR8AppModule {
 }
 
 
-object wear extends BaseHiltAndroidModule, AndroidR8AppModule {
-  override def androidApplicationNamespace: String = "com.example.jetcaster"
-
-  override def androidApplicationId: String = "com.example.jetcaster"
-
-  override def androidMinSdk: T[Int] = 26
-
-  override def androidTargetSdk: T[Int] = 34
-
-  def androidEnableCompose: T[Boolean] = true
-
-  def bomMvnDeps: T[Seq[Dep]] = Seq(
-    mvn"androidx.compose:compose-bom-alpha:2025.06.00"
-  )
-
-  def kotlinSymbolProcessors: T[Seq[Dep]] = Seq(
-    mvn"com.google.dagger:hilt-compiler:2.56.2",
-  )
-
-  override def androidDebugSettings: T[AndroidBuildTypeSettings] = Task {
-    AndroidBuildTypeSettings(
-      isMinifyEnabled = false
-    )
-  }
-
-  def androidProjectProguardFiles = Task.Sources(
-    "proguard-rules.pro"
-  )
-
-  def androidDefaultProguardFileNames: Task[Seq[String]] = Task.Anon {
-    Seq("proguard-android-optimize.txt")
-  }
-
+object wear extends BaseJetcasterAppModule {
 
   private def debugMvnDeps: T[Seq[Dep]] = Task {
     Seq(

--- a/Jetcaster/package.mill
+++ b/Jetcaster/package.mill
@@ -354,7 +354,7 @@ object tv extends BaseJetcasterAppModule {
   override def androidVirtualDevice = AndroidVirtualDevice(
     apiVersion = "android-34",
     architecture = "x86",
-    deviceId = "tv_1080p",
+    deviceId = "tv_720p",
     systemImageSource = "android-tv"
   )
 

--- a/Jetcaster/package.mill
+++ b/Jetcaster/package.mill
@@ -352,9 +352,9 @@ object tv extends BaseJetcasterAppModule {
     Seq[Regex]("^/META-INF/(AL2.0|LGPL2.1)$".r, "/*.jar".r, "/*.jar".r)
 
   override def androidVirtualDevice = AndroidVirtualDevice(
-    apiVersion = "android-34",
+    apiVersion = "android-33",
     architecture = "x86",
-    deviceId = "tv_720p",
+    deviceId = "tv_1080p",
     systemImageSource = "android-tv"
   )
 

--- a/Jetcaster/package.mill
+++ b/Jetcaster/package.mill
@@ -361,7 +361,7 @@ object tv extends BaseJetcasterAppModule {
 }
 
 
-object wear extends BaseJetcasterAppModule {
+object wear extends BaseJetcasterAppModule { outer =>
 
   override def androidMinSdk: T[Int] = Task {26}
 
@@ -445,6 +445,12 @@ object wear extends BaseJetcasterAppModule {
     override def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
       mvn"androidx.compose.ui:ui-test-junit4",
       mvn"org.robolectric:robolectric:4.14.1",
+      mvn"io.github.takahirom.roborazzi:roborazzi:1.48.0",
+      mvn"io.github.takahirom.roborazzi:roborazzi:1.48.0",
+      mvn"io.github.takahirom.roborazzi:roborazzi-compose:1.48.0",
+      mvn"io.github.takahirom.roborazzi:roborazzi-junit-rule:1.48.0",
+      mvn"com.google.android.horologist:horologist-roboscreenshots:0.7.15",
+
       // Resolve conflicts
       mvn"androidx.test.ext:junit:1.2.1".forceVersion(),
       mvn"androidx.test:monitor:1.7.2".forceVersion(),

--- a/Jetcaster/package.mill
+++ b/Jetcaster/package.mill
@@ -247,9 +247,6 @@ trait BaseJetcasterAppModule extends BaseHiltAndroidModule, AndroidR8AppModule {
       )
     })
   }
-}
-
-object mobile extends BaseJetcasterAppModule {
 
   // Missing org.jaxen.*
   override def androidR8Args = Seq(
@@ -260,7 +257,9 @@ object mobile extends BaseJetcasterAppModule {
     // Missing javax.lang.model.*
     "--lib", androidR8JavaHome().path.toString
   )
+}
 
+object mobile extends BaseJetcasterAppModule {
 
   private def debugMvnDeps: T[Seq[Dep]] = Task {
       Seq(
@@ -316,6 +315,8 @@ object mobile extends BaseJetcasterAppModule {
 
 object tv extends BaseJetcasterAppModule {
 
+  override def androidApplicationNamespace: String = "com.example.jetcaster.tv"
+
   private def debugMvnDeps: T[Seq[Dep]] = Task {
     Seq(
       mvn"androidx.compose.ui:ui-tooling",
@@ -355,10 +356,17 @@ object tv extends BaseJetcasterAppModule {
   override def androidExcludePackageFiles: T[Seq[Regex]] =
     Seq[Regex]("^/META-INF/(AL2.0|LGPL2.1)$".r, "/*.jar".r, "/*.jar".r)
 
-  // Use google-tv image
+
+  // Use system-images;android-34;android-tv;x86 image
+  override def androidEmulatorArchitecture = "x86"
+
+  override def androidVirtualDeviceIdentifier = "test-tv"
+
+  override def androidDeviceId = "tv_1080p"
+
   override def sdkInstallSystemImage(): Command[String] = Task.Command {
     val image =
-      s"system-images;${androidSdkModule().platformsVersion()};google-tv;$androidEmulatorArchitecture"
+      s"system-images;android-34;android-tv;$androidEmulatorArchitecture"
     Task.log.info(s"Downloading $image")
     val installCall = os.call((
       androidSdkModule().sdkManagerExe().path,
@@ -402,7 +410,12 @@ object wear extends BaseJetcasterAppModule {
     Seq[Regex]("^/META-INF/(AL2.0|LGPL2.1)$".r, "/*.jar".r, "^rome-utils-.*\\.jar$".r)
 
 
-  // Use android-wear image
+  // Use system-images;android-34;android-tv;x86_64 image
+
+  override def androidVirtualDeviceIdentifier = "test-wear"
+
+  override def androidDeviceId = "wearos_large_round"
+
   override def sdkInstallSystemImage(): Command[String] = Task.Command {
     val image =
       s"system-images;android-34;android-wear;$androidEmulatorArchitecture"

--- a/Jetcaster/package.mill
+++ b/Jetcaster/package.mill
@@ -389,7 +389,8 @@ object wear extends BaseJetcasterAppModule {
 
   private def debugMvnDeps: T[Seq[Dep]] = Task {
     Seq(
-
+      mvn"androidx.compose.ui:ui-tooling",
+      mvn"androidx.compose.ui:ui-test-manifest"
     )
   }
 
@@ -403,6 +404,38 @@ object wear extends BaseJetcasterAppModule {
 
   override def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
 
+    mvn"androidx.activity:activity-compose:1.10.1",
+    mvn"androidx.core:core-splashscreen:1.0.1",
+    mvn"androidx.wear.compose:compose-material3:1.5.0-beta03",
+    mvn"androidx.compose.material3:material3",
+    mvn"org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0",
+    mvn"androidx.wear.compose:compose-foundation:1.5.0-beta03",
+    mvn"androidx.media3:media3-exoplayer:1.7.1",
+    mvn"androidx.media3:media3-session:1.7.1",
+    mvn"androidx.media3:media3-ui-compose:1.7.1",
+    mvn"androidx.media3:media3-common-ktx:1.7.1",
+
+    // Horologist
+    mvn"com.google.android.horologist:horologist-compose-layout:0.7.14-beta",
+    mvn"com.google.android.horologist:horologist-media-ui:0.7.14-beta",
+    mvn"com.google.android.horologist:horologist-media-ui-material3:0.7.14-beta",
+    mvn"com.google.android.horologist:horologist-audio-ui-model:0.7.14-beta",
+    mvn"com.google.android.horologist:horologist-audio-ui:0.7.14-beta",
+    mvn"com.google.android.horologist:horologist-audio-ui-material3:0.7.14-beta",
+    mvn"com.google.android.horologist:horologist-audio-ui-model:0.7.14-beta",
+    mvn"com.google.android.horologist:horologist-media-data:0.7.14-beta",
+    mvn"com.google.android.horologist:horologist-images-coil:0.7.14-beta",
+
+    // Hilt
+    mvn"androidx.hilt:hilt-navigation-compose:1.2.0",
+    mvn"com.google.dagger:hilt-android:2.56.2",
+
+    mvn"androidx.compose.ui:ui-tooling-preview",
+    mvn"androidx.compose.ui:ui-tooling",
+
+    mvn"androidx.wear.compose:compose-navigation:1.5.0-beta03",
+    mvn"androidx.compose.ui:ui-test-manifest",
+    mvn"io.coil-kt:coil-compose:2.7.0",
   ) ++ (if (androidIsDebug()) debugMvnDeps() else Seq())
 
 
@@ -441,4 +474,6 @@ object wear extends BaseJetcasterAppModule {
       "-opt-in=kotlin.RequiresOptIn",
       "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
     )
+
+  // TODO: Add androidTest
 }

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.1.0-RC3-156-47444a
+//| mill-version: 1.1.0-RC4-18-0577b3
 package build
 import mill.*, androidlib.*, kotlinlib.*
 

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.1.0-RC3-101-27088a
+//| mill-version: 1.1.0-RC3-156-47444a
 package build
 import mill.*, androidlib.*, kotlinlib.*
 


### PR DESCRIPTION
#### TV
<img width="1169" height="693" alt="image" src="https://github.com/user-attachments/assets/113b90d4-7529-40cc-8367-b5ea483e4bfd" />

#### wear - Not working yet

- `assets` directory missing from our apk 
  `java.io.FileNotFoundException: lottie/M3PlayPause.json`
- tests crash:
```
Running Test Class com.example.jetcaster.NavigationTest
1-772] WARNING: No manifest file found at ./AndroidManifest.xml.
1-772] Falling back to the Android OS resources only.
1-772] To remove this warning, annotate your test class with @Config(manifest=Config.NONE).
1-772] If you're using Android Gradle Plugin, add testOptions.unitTests.includeAndroidResources = true to your build.gradle
1-772] Test run com.example.jetcaster.NavigationTest started
1-772] Test com.example.jetcaster.NavigationTest.launchAndNavigate started
1-772] Test com.example.jetcaster.NavigationTest.launchAndNavigate failed: java.lang.RuntimeException: Unable to resolve activity for Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] cmp=org.robolectric.default/com.example.jetcaster.MainActivity } -- see https://github.com/robolectric/robolectric/pull/4736 for details, took 1.44 sec
```