### PR TITLE
Fix actions warnings about NodeJs20

### DIFF
--- a/.github/workflows/CustomMillTest.yaml
+++ b/.github/workflows/CustomMillTest.yaml
@@ -1,6 +1,7 @@
 name: Custom Mill Test
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       mill_repo:

--- a/.github/workflows/CustomMillTest.yaml
+++ b/.github/workflows/CustomMillTest.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Mill
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.inputs.mill_repo || 'com-lihaoyi/mill' }}
           ref: ${{ github.event.inputs.mill_branch || 'main' }}
@@ -26,7 +26,7 @@ jobs:
           path: mill
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -45,7 +45,7 @@ jobs:
         shell: bash
 
       - name: Upload Mill Bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mill-custom-bundle
           path: mill-bundle/

--- a/.github/workflows/CustomMillTest.yaml
+++ b/.github/workflows/CustomMillTest.yaml
@@ -1,7 +1,6 @@
 name: Custom Mill Test
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       mill_repo:

--- a/.github/workflows/_run-tests.yaml
+++ b/.github/workflows/_run-tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [ JetLagged.app ]
+        app: [ JetLagged.app, JetNews.app, Jetsnack.app, Jetchat.app ]
     steps:
       - uses: actions/checkout@v6
       - name: Download and Restore Custom Mill Bundle
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [ Reply.app ]
+        app: [ Reply.app, Jetcaster.mobile, Jetcaster.tv, Jetcaster.wear ]
         include:
           - app: Reply.app
             app-activity: com.example.reply.ui.MainActivity

--- a/.github/workflows/_run-tests.yaml
+++ b/.github/workflows/_run-tests.yaml
@@ -18,10 +18,10 @@ jobs:
       matrix:
         app: [ JetLagged.app, JetNews.app, Jetsnack.app, Jetchat.app ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download and Restore Custom Mill Bundle
         if: ${{ inputs.use_custom_mill }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mill-custom-bundle
           path: mill-bundle
@@ -37,13 +37,13 @@ jobs:
           ln -s "$(pwd)/mill-bundle/mill-proguard.jar" mill
           chmod +x mill
         shell: bash
-      - uses: coursier/cache-action@v6
+      - uses: coursier/cache-action@v8
       - uses: ./.github/actions/android-setup
       - uses: ./.github/actions/mill-android-test
         with:
           app-name: ${{ matrix.app }}
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         if: (!cancelled())
         with:
           fail_on_failure: false
@@ -71,10 +71,10 @@ jobs:
           - app: Jetcaster.wear
             app-activity: .MainActivity
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download and Restore Custom Mill Bundle
         if: ${{ inputs.use_custom_mill }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mill-custom-bundle
           path: mill-bundle
@@ -88,7 +88,7 @@ jobs:
           ln -s "$(pwd)/mill-bundle/mill-proguard.jar" mill
           chmod +x mill
         shell: bash
-      - uses: coursier/cache-action@v6
+      - uses: coursier/cache-action@v8
       - uses: ./.github/actions/android-setup
       - uses: ./.github/actions/mill-android-run-apps
         with:
@@ -104,10 +104,10 @@ jobs:
       matrix:
         app: [ Jetcaster.wear ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download and Restore Custom Mill Bundle
         if: ${{ inputs.use_custom_mill }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mill-custom-bundle
           path: mill-bundle
@@ -121,13 +121,13 @@ jobs:
           ln -s "$(pwd)/mill-bundle/mill-proguard.jar" mill
           chmod +x mill
         shell: bash
-      - uses: coursier/cache-action@v6
+      - uses: coursier/cache-action@v8
       - uses: ./.github/actions/android-setup
       - uses: ./.github/actions/mill-android-unit-test
         with:
           app-name: ${{ matrix.app }}
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         if: (!cancelled())
         with:
           fail_on_failure: false

--- a/.github/workflows/_run-tests.yaml
+++ b/.github/workflows/_run-tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [ JetLagged.app, JetNews.app, Jetsnack.app, Jetchat.app ]
+        app: [ JetLagged.app ]
     steps:
       - uses: actions/checkout@v6
       - name: Download and Restore Custom Mill Bundle
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [ Reply.app, Jetcaster.mobile, Jetcaster.tv, Jetcaster.wear ]
+        app: [ Reply.app ]
         include:
           - app: Reply.app
             app-activity: com.example.reply.ui.MainActivity


### PR DESCRIPTION
To close #24 

Bumps up the actions to their latest versions that use >= NodeJs 24

Runs without warning:
- https://github.com/vaslabs-ltd/compose-samples-with-mill/actions/runs/24145713034?pr=25
- https://github.com/vaslabs-ltd/compose-samples-with-mill/actions/runs/24145653913